### PR TITLE
fix: setting naming and s3 prefix metric

### DIFF
--- a/hamlet/s3support/extensions/s3_age_metric/extension.ftl
+++ b/hamlet/s3support/extensions/s3_age_metric/extension.ftl
@@ -24,6 +24,13 @@
         ]
     /]
 
+    [#-- Setting available for metric dimensions to lookup --]
+    [@Settings
+        {
+            "S3_PATH" : "s3://${BUCKET_NAME}/${BUCKET_PREFIX}"
+        }
+    /]
+
     [#-- CloudWatch Metrics --]
     [#local cloudwatchNamespace = (_context.DefaultEnvironment["CLOUDWATCH_METRIC_NAMESPACE"])!"" ]
     [#if cloudwatchNamespace?has_content ]

--- a/hamlet/s3support/extensions/s3_age_metric/extension.ftl
+++ b/hamlet/s3support/extensions/s3_age_metric/extension.ftl
@@ -27,7 +27,11 @@
     [#-- Setting available for metric dimensions to lookup --]
     [@Settings
         {
-            "S3_PATH" : "s3://${BUCKET_NAME}/${BUCKET_PREFIX}"
+            "S3_PATH" : formatRelativePath(
+                            "s3://",
+                            (_context.DefaultEnvironment["BUCKET_NAME"])!"",
+                            (_context.DefaultEnvironment["BUCKET_PREFIX"])!""
+                        )?ensure_ends_with("/")
         }
     /]
 

--- a/hamlet/s3support/modules/s3_age_metric/module.ftl
+++ b/hamlet/s3support/modules/s3_age_metric/module.ftl
@@ -75,7 +75,7 @@
 
     [#local lambdaId = formatName(id, "lambda") ]
 
-    [#local lambdaSettingsNamespace = formatName(namespace, tier, id, instance)]
+    [#local lambdaSettingsNamespace = formatName(namespace, tier, getComponentName(lambdaId), instance)]
 
     [#-- Lambda Configuration --]
     [@loadModule

--- a/hamlet/s3support/modules/s3_inventory_copy/module.ftl
+++ b/hamlet/s3support/modules/s3_inventory_copy/module.ftl
@@ -127,8 +127,8 @@
 
     [#local lambdaId = formatName(id, "lambda") ]
 
-    [#local s3EventSettingsNamespace = formatName(namespace, tier, id, "s3event", instance)]
-    [#local s3BatchSettingsNamespace = formatName(namespace, tier, id, "s3batch", instance )]
+    [#local s3EventSettingsNamespace = formatName(namespace, tier, getComponentName(lambdaId), "s3event", instance)]
+    [#local s3BatchSettingsNamespace = formatName(namespace, tier, getComponentName(lambdaId), "s3batch", instance )]
 
     [#local s3SourceDeploymentProfile = concatenate([id, instance, s3InventoryProfileSuffix], "_")]
 


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Fixes a bug in the setting namespace where the namespace didn't align with the component name
- Adds an S3_PREFIX setting which can be used as the dimension source for cloud watch alarms

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
The namespace setting allows for using component ids with - in the id 
The S3_PREFIX saves having to create your own extension to get the same property

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

